### PR TITLE
feat: mechanism for draining queue

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,11 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+
+[*.json]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,9 +9,4 @@ indent_style = space
 indent_size = 4
 
 [*.json]
-end_of_line = lf
-charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true
-indent_style = space
 indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.3.1"></a>
+## [1.3.1](https://github.com/StyleLounge/http-queue/compare/v1.2.0...v1.3.1) (2017-01-09)
+
+
+### Bug Fixes
+
+* resolve promise after finishing the HTTP request ([91a1730](https://github.com/StyleLounge/http-queue/commit/91a1730))
+
+
+
 <a name="1.2.0"></a>
 # [1.2.0](https://github.com/StyleLounge/http-queue/compare/v1.1.1...v1.2.0) (2016-09-15)
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,24 @@ npm i --save @style/http-queue
 ```js
 import queue from '@style/http-queue';
 
-const schedule = queue();
+async () => {
+    const { schedule, drain } = queue();
 
-schedule({verb: 'POST', url: 'http://analytics.stylelounge.de', data: {foo: 'bar'}});
+    // Schedule some HTTP requests
+    schedule({verb: 'POST', url: 'http://analytics.stylelounge.de', data: {character: 'Almec'}});
+    schedule({verb: 'POST', url: 'http://analytics.stylelounge.de', data: {character: 'Amee'}});
+    schedule({verb: 'POST', url: 'http://analytics.stylelounge.de', data: {character: 'Darth Bane'}});
+    schedule({verb: 'POST', url: 'http://analytics.stylelounge.de', data: {character: 'Beed'}});
+    schedule({verb: 'POST', url: 'http://analytics.stylelounge.de', data: {character: 'Sio Bibble'}});
+    schedule({verb: 'POST', url: 'http://analytics.stylelounge.de', data: {character: 'Dengar'}});
+    schedule({verb: 'POST', url: 'http://analytics.stylelounge.de', data: {character: 'Feral'}});
+
+    // Let's drain the queue ("waits" until all requests has been sent OR terminates after configurable
+    // timeout; default = 3000 ms)
+    await drain();
+};
 ```
+
 ## Debugging
 
 The library uses the [debug](https://github.com/visionmedia/debug) library internally. You can activate the debug messages by executing the following in your console:

--- a/package.json
+++ b/package.json
@@ -1,62 +1,62 @@
 {
-    "name": "@style/http-queue",
-    "version": "1.3.0",
-    "description": "A fire-and-forget HTTP request queue implementation for browsers.",
-    "author": "SNM Style Net Media GmbH",
-    "contributors": [
-        {
-            "name": "André König",
-            "email": "andre.koenig@stylelounge.com"
-        }
-    ],
-    "scripts": {
-        "build": "./scripts/build",
-        "compile": "./scripts/compile",
-        "lint": "./scripts/lint",
-        "test": "./scripts/test",
-        "watch": "./scripts/watch",
-        "precommit": "./scripts/precommit",
-        "commitmsg": "./scripts/commitmsg",
-        "validate-commit-message": "./scripts/validate-commit-message",
-        "release": "./scripts/release"
-    },
-    "main": "./dist/index.js",
-    "typings": "./dist/index.d.ts",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/StyleLounge/http-queue.git"
-    },
-    "keywords": [
-        "http",
-        "queue",
-        "browsers"
-    ],
-    "license": "SEE LICENSE IN license.md",
-    "bugs": {
-        "url": "https://github.com/StyleLounge/http-queue/issues"
-    },
-    "homepage": "https://github.com/StyleLounge/http-queue#readme",
-    "devDependencies": {
-        "@types/chai": "^3.4.34",
-        "@types/debug": "^0.0.29",
-        "@types/mocha": "^2.2.36",
-        "@types/node": "^6.0.58",
-        "@types/redux-actions": "^1.2.2",
-        "chai": "^3.5.0",
-        "husky": "^0.12.0",
-        "mocha": "^2.5.3",
-        "standard-version": "^2.4.0",
-        "tslint": "^3.13.0",
-        "typescript": "^2.1.4",
-        "validate-commit-message": "^3.0.1"
-    },
-    "dependencies": {
-        "basil.js": "^0.4.4",
-        "debug": "^2.2.0",
-        "http-client": "^4.1.0",
-        "isomorphic-fetch": "^2.2.1",
-        "redux": "^3.5.2",
-        "redux-actions": "^0.10.1",
-        "redux-saga": "0.11.0"
+  "name": "@style/http-queue",
+  "version": "1.3.1",
+  "description": "A fire-and-forget HTTP request queue implementation for browsers.",
+  "author": "SNM Style Net Media GmbH",
+  "contributors": [
+    {
+      "name": "André König",
+      "email": "andre.koenig@stylelounge.com"
     }
+  ],
+  "scripts": {
+    "build": "./scripts/build",
+    "compile": "./scripts/compile",
+    "lint": "./scripts/lint",
+    "test": "./scripts/test",
+    "watch": "./scripts/watch",
+    "precommit": "./scripts/precommit",
+    "commitmsg": "./scripts/commitmsg",
+    "validate-commit-message": "./scripts/validate-commit-message",
+    "release": "./scripts/release"
+  },
+  "main": "./dist/index.js",
+  "typings": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/StyleLounge/http-queue.git"
+  },
+  "keywords": [
+    "http",
+    "queue",
+    "browsers"
+  ],
+  "license": "SEE LICENSE IN license.md",
+  "bugs": {
+    "url": "https://github.com/StyleLounge/http-queue/issues"
+  },
+  "homepage": "https://github.com/StyleLounge/http-queue#readme",
+  "devDependencies": {
+    "@types/chai": "^3.4.34",
+    "@types/debug": "^0.0.29",
+    "@types/mocha": "^2.2.36",
+    "@types/node": "^6.0.58",
+    "@types/redux-actions": "^1.2.2",
+    "chai": "^3.5.0",
+    "husky": "^0.12.0",
+    "mocha": "^2.5.3",
+    "standard-version": "^2.4.0",
+    "tslint": "^3.13.0",
+    "typescript": "^2.1.4",
+    "validate-commit-message": "^3.0.1"
+  },
+  "dependencies": {
+    "basil.js": "^0.4.4",
+    "debug": "^2.2.0",
+    "http-client": "^4.1.0",
+    "isomorphic-fetch": "^2.2.1",
+    "redux": "^3.5.2",
+    "redux-actions": "^0.10.1",
+    "redux-saga": "0.11.0"
+  }
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,25 +6,36 @@
  * MIT Licensed
  */
 
+import * as debug from "debug";
+
 import uuid from "./utils/uuid";
 
 import createStore from "./store";
 import sagas from "./sagas";
 import reducer from "./reducer";
 
+import { IRequest } from "./types";
 import { add } from "./actions";
+
+const dbg: debug.IDebugger = debug("@stylelounge/http-queue");
 
 const middlewares = { sagas };
 
-export interface IRequest {
-    verb: string;
-    url: string;
-    data?: Object;
-}
+type HttpQueue = {
+    schedule: (manifest: IRequest) => void,
+    drain: (timeout?: number) => Promise<void>
+};
 
-const queue = () => {
+const createHttpQueue = (): HttpQueue => {
     const store = createStore({ reducer, middlewares });
 
+    /**
+     * Schedules a HTTP request.
+     *
+     * @param {IRequest} request The request definition
+     * @returns void
+     *
+     */
     const schedule = (manifest: IRequest) => {
         store.dispatch(
             add({
@@ -34,7 +45,38 @@ const queue = () => {
         );
     };
 
-    return schedule;
+    /**
+     * Drains the queue and resolves when the queue is empty OR a
+     * given timeout is exceeded.
+     *
+     * @param {number} timeout Resolves the promise after timeout has exceeded
+     *
+     * @returns {Promise<void>}
+     *
+     */
+    const drain = async (timeout: number = 3000) => {
+        dbg(`Drain requested (timeout: ${timeout})`);
+
+        const NAP_TIME = 50;
+        const allowedCatNaps = Math.round(timeout / NAP_TIME);
+
+        let actualCatNaps = 0;
+        let drained = false;
+
+        do {
+            await new Promise(resolve => setTimeout(resolve, NAP_TIME));
+
+            actualCatNaps = actualCatNaps + 1;
+
+            drained = actualCatNaps >= allowedCatNaps || store.getState().manifests.length === 0;
+        } while (!drained);
+
+        // tslint:disable-next-line
+        dbg(`Drained queue. Some stats: allowed naps: ${allowedCatNaps}, actual naps: ${actualCatNaps}, drained? ${drained} (configured timeout: ${timeout})`);
+    };
+
+    return { drain, schedule };
 };
 
-export default queue;
+export default createHttpQueue;
+export { HttpQueue };

--- a/src/lib/reducer/index.spec.ts
+++ b/src/lib/reducer/index.spec.ts
@@ -10,9 +10,9 @@ import { expect } from "chai";
 
 import { add, remove, restore } from "../actions";
 
-import { IManifest } from "../types";
+import { IManifest, IState } from "../types";
 
-import reducer, { IState } from "./";
+import reducer from "./";
 
 describe("The reducer", function () {
     it("should be able to handle 'ADD'", function (done) {

--- a/src/lib/reducer/index.ts
+++ b/src/lib/reducer/index.ts
@@ -14,11 +14,7 @@ import {
     REMOVE,
 } from "../constants/actions";
 
-import { IManifest } from "../types";
-
-export interface IState {
-    manifests: IManifest[];
-}
+import { IState, IManifest } from "../types";
 
 const createState = (): IState => ({
     manifests: [],

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -6,8 +6,10 @@
  * MIT Licensed
  */
 
-import {createStore, applyMiddleware, compose, Store} from "redux";
+import { createStore, applyMiddleware, compose, Store } from "redux";
 import createSagaMiddleware from "redux-saga";
+
+import { IState } from "../types";
 
 export interface IMiddlewares {
     sagas: Function[];
@@ -17,14 +19,14 @@ export interface IMiddlewares {
 export interface IOptions {
     middlewares: IMiddlewares;
     reducer: any;
-    initialState?: Object;
+    initialState?: IState;
 }
 
-function configureStore (options: IOptions): Store<any> {
+function configureStore(options: IOptions): Store<IState> {
     const sagaMiddleware = createSagaMiddleware();
     const {reducer, initialState} = options;
 
-    const store = createStore(
+    const store = createStore<IState>(
         reducer,
         initialState,
         compose(

--- a/src/lib/types/IRequest.ts
+++ b/src/lib/types/IRequest.ts
@@ -1,0 +1,15 @@
+/**
+ *
+ * stylelounge.de
+ *
+ * Copyright (C) SNM Style Net Media GmbH
+ * MIT Licensed
+ */
+
+interface IRequest {
+    verb: string;
+    url: string;
+    data?: Object;
+}
+
+export default IRequest;

--- a/src/lib/types/IState.ts
+++ b/src/lib/types/IState.ts
@@ -7,11 +7,9 @@
  */
 
 import IManifest from "./IManifest";
-import IRequest from "./IRequest";
-import IState from "./IState";
 
-export {
-    IManifest,
-    IRequest,
-    IState
-};
+interface IState {
+    manifests: IManifest[];
+}
+
+export default IState;

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,6 @@
 {
-    "extends": "tslint:recommended",
-    "rules": {
-        "no-var-requires": false
-    }
+  "extends": "tslint:recommended",
+  "rules": {
+    "no-var-requires": false
+  }
 }


### PR DESCRIPTION
This PR contains the new feature for draining the queue. There are sometimes situation where you want to drain the queue manually. The function returns a `Promise` which resolves either when no requests are left in the queue *OR* a passed timeout has been exceeded (default: `3000 ms`).